### PR TITLE
Add RED IPP2 ODT curve info

### DIFF
--- a/lutcomparetool_app.py
+++ b/lutcomparetool_app.py
@@ -141,6 +141,13 @@ CURVE_INFO = {
         "color_transform": red_wide_gamut_rgb_to_rec709,
         "description": "RED Log Film"
     },
+    "red_ipp2_odt_approx": {
+        "curve_func": linear_to_red_ipp2_odt_approx,
+        "inverse_func": red_ipp2_odt_approx_to_linear,
+        "color_space": "red_wide_gamut_rgb",
+        "color_transform": red_wide_gamut_rgb_to_rec709,
+        "description": "RED IPP2 ODT Approximation"
+    },
     
     # Other Curves
     "vlog": {


### PR DESCRIPTION
## Summary
- add CURVE_INFO mapping for `red_ipp2_odt_approx`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68420695e6bc833293a87e780f2e961b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new curve configuration for "RED IPP2 ODT Approximation" in the `lutcomparetool_app.py` script.

### Why are these changes being made?

This change integrates support for the RED IPP2 ODT Approximation curve, expanding the application's capability to handle and transform data within the RED wide gamut RGB color space, ultimately aiding users needing this specific conversion. The addition ensures that users can apply the RED IPP2 ODT curve functions directly, following the existing project structure for defining color transformation curves.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nowe funkcje**
  - Dodano nową krzywą "RED IPP2 ODT Approximation" do dostępnych opcji w narzędziu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->