### PR TITLE
Fix API launch command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,12 +306,7 @@ batch_results = response.json()
 
 Start the API server:
 ```bash
-python api_server.py
+python lutcomparetool_app.py
 ```
 
 The server will be available at `http://localhost:8080/api`.
-
-For development, you can enable debug mode:
-```bash
-python api_server.py --debug
-```


### PR DESCRIPTION
## Summary
- update instructions in README for starting the API server

## Testing
- `pre-commit` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68420694507883329ab17ccc1a6cd3c1

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the API launch command in the README to reference the correct file `lutcomparetool_app.py` and remove outdated debug mode instructions.

### Why are these changes being made?

The original command was incorrect, referencing a non-existent or outdated file `api_server.py`, which could lead to confusion. The removal of the debug mode instructions suggests it is either no longer supported or irrelevant, streamlining the documentation for clarity and accuracy.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dokumentacja**
  - Zaktualizowano instrukcje uruchamiania serwera API w pliku README.
  - Usunięto informacje dotyczące trybu debugowania podczas rozwoju.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->